### PR TITLE
Capstone v4

### DIFF
--- a/hapstone.cabal
+++ b/hapstone.cabal
@@ -32,8 +32,6 @@ library
   build-depends:       base >= 4.7 && < 5
   default-language:    Haskell2010
   extra-libraries:     capstone
-  extra-lib-dirs:      /home/thewormkill/clones/forks/capstone/tests
-  include-dirs:        /home/thewormkill/clones/forks/capstone/include
   build-tool-depends: c2hs:c2hs >= 0.28.7
 
 test-suite hapstone-test

--- a/hapstone.cabal
+++ b/hapstone.cabal
@@ -34,7 +34,7 @@ library
   extra-libraries:     capstone
   extra-lib-dirs:      /home/thewormkill/clones/forks/capstone/tests
   include-dirs:        /home/thewormkill/clones/forks/capstone/include
-  build-tools:         c2hs
+  build-tool-depends: c2hs:c2hs >= 0.28.7
 
 test-suite hapstone-test
   type:                exitcode-stdio-1.0

--- a/hapstone.cabal
+++ b/hapstone.cabal
@@ -10,7 +10,7 @@ maintainer:          twk@twki.de
 copyright:           2016 - 2017 Inokentiy Babushkin
 category:            Disassembler
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       >=2.0
 
 library
   hs-source-dirs:      src

--- a/hapstone.cabal
+++ b/hapstone.cabal
@@ -51,7 +51,7 @@ test-suite hapstone-test
                        Internal.Sparc.StorableSpec,
                        Internal.Sparc.Default,
                        Internal.SystemZ.StorableSpec,
-                       Internal.SystemZ.Default
+                       Internal.SystemZ.Default,
                        Internal.X86.StorableSpec,
                        Internal.X86.Default,
                        Internal.XCore.StorableSpec,

--- a/src/Hapstone/Capstone.hs
+++ b/src/Hapstone/Capstone.hs
@@ -13,7 +13,7 @@ of versatility.
 
 TODO: write a proper user guide here.
 -}
-module Hapstone.Capstone 
+module Hapstone.Capstone
     ( disasmIO
     , disasmSimpleIO
     , Disassembler(..)
@@ -40,7 +40,7 @@ foreign import ccall "wrapper"
 
 -- | wrap a relatively safe function to get a callback
 -- "safe" in this context means that the buffer remains unmodified
-mkCallback :: Storable a 
+mkCallback :: Storable a
            => (([Word8], [Word8]) -> a -> IO CSize)
            -> IO CsSkipdataCallback
 mkCallback = allocCallback . mkCallback'

--- a/src/Hapstone/Internal/Capstone.chs
+++ b/src/Hapstone/Internal/Capstone.chs
@@ -214,19 +214,19 @@ instance Storable CsDetail where
                peekArray num ptr
         <*> pure Nothing
     poke p (CsDetail rR rW g a) = do
-        {#set cs_detail->regs_read_count#} p (fromIntegral $ length rR)
+        {#set cs_detail->regs_read_count#} p $ fromIntegral $ length rR
         if length rR > 12
            then error "regs_read overflew 12 elements (24 bytes)"
            else pokeArray (plusPtr p {#offsetof cs_detail.regs_read#}) rR
-        {#set cs_detail->regs_write_count#} p (fromIntegral $ length rW)
+        {#set cs_detail->regs_write_count#} p $ fromIntegral $ length rW
         if length rW > 20
            then error "regs_write overflew 20 elements (40 bytes)"
            else pokeArray (plusPtr p {#offsetof cs_detail.regs_write#}) rW
-        {#set cs_detail->groups_count#} p (fromIntegral $ length g)
+        {#set cs_detail->groups_count#} p $ fromIntegral $ length g
         if length g > 8
            then error "groups overflew 8 bytes"
            else pokeArray (plusPtr p {#offsetof cs_detail.groups#}) g
-        let bP = plusPtr p ({#offsetof cs_detail.groups_count#} + 1)
+        let bP = plusPtr p $ {#offsetof cs_detail.groups_count#} + 1
         case a of
           Just (X86 x) -> poke bP x
           Just (Arm64 x) -> poke bP x

--- a/src/Hapstone/Internal/Capstone.chs
+++ b/src/Hapstone/Internal/Capstone.chs
@@ -200,8 +200,8 @@ data CsDetail = CsDetail
 -- for that.
 
 instance Storable CsDetail where
-    sizeOf _ = 1560
-    alignment _ = 8
+    sizeOf _ = {#sizeof cs_detail#}
+    alignment _ = {#alignof cs_detail#}
     peek p = CsDetail
         <$> do num <- fromIntegral <$> {#get cs_detail->regs_read_count#} p
                let ptr = plusPtr p {#offsetof cs_detail.regs_read#}

--- a/src/Hapstone/Internal/Capstone.chs
+++ b/src/Hapstone/Internal/Capstone.chs
@@ -186,8 +186,8 @@ data ArchInfo
 
 -- | instruction information
 data CsDetail = CsDetail
-    { regsRead :: [Word8] -- ^ registers read by this instruction
-    , regsWrite :: [Word8] -- ^ registers written by this instruction
+    { regsRead :: [Word16] -- ^ registers read by this instruction
+    , regsWrite :: [Word16] -- ^ registers written by this instruction
     , groups :: [Word8] -- ^ instruction groups this instruction belongs to
     , archInfo :: Maybe ArchInfo -- ^ (optional) architecture-specific info
     } deriving (Show, Eq)
@@ -216,11 +216,11 @@ instance Storable CsDetail where
     poke p (CsDetail rR rW g a) = do
         {#set cs_detail->regs_read_count#} p (fromIntegral $ length rR)
         if length rR > 12
-           then error "regs_read overflew 12 bytes"
+           then error "regs_read overflew 12 elements (24 bytes)"
            else pokeArray (plusPtr p {#offsetof cs_detail.regs_read#}) rR
         {#set cs_detail->regs_write_count#} p (fromIntegral $ length rW)
         if length rW > 20
-           then error "regs_write overflew 20 bytes"
+           then error "regs_write overflew 20 elements (40 bytes)"
            else pokeArray (plusPtr p {#offsetof cs_detail.regs_write#}) rW
         {#set cs_detail->groups_count#} p (fromIntegral $ length g)
         if length g > 8

--- a/src/Hapstone/Internal/Capstone.chs
+++ b/src/Hapstone/Internal/Capstone.chs
@@ -203,30 +203,30 @@ instance Storable CsDetail where
     sizeOf _ = {#sizeof cs_detail#}
     alignment _ = {#alignof cs_detail#}
     peek p = CsDetail
-        <$> do num <- fromIntegral <$> {#get cs_detail->regs_read_count#} p
+        <$> do num <- fromIntegral <$> {#get cs_detail.regs_read_count#} p
                let ptr = plusPtr p {#offsetof cs_detail.regs_read#}
                peekArray num ptr
-        <*> do num <- fromIntegral <$> {#get cs_detail->regs_write_count#} p
+        <*> do num <- fromIntegral <$> {#get cs_detail.regs_write_count#} p
                let ptr = plusPtr p {#offsetof cs_detail.regs_write#}
                peekArray num ptr
-        <*> do num <- fromIntegral <$> {#get cs_detail->groups_count#} p
+        <*> do num <- fromIntegral <$> {#get cs_detail.groups_count#} p
                let ptr = plusPtr p {#offsetof cs_detail.groups#}
                peekArray num ptr
         <*> pure Nothing
     poke p (CsDetail rR rW g a) = do
-        {#set cs_detail->regs_read_count#} p $ fromIntegral $ length rR
+        {#set cs_detail.regs_read_count#} p $ fromIntegral $ length rR
         if length rR > 12
            then error "regs_read overflew 12 elements (24 bytes)"
            else pokeArray (plusPtr p {#offsetof cs_detail.regs_read#}) rR
-        {#set cs_detail->regs_write_count#} p $ fromIntegral $ length rW
+        {#set cs_detail.regs_write_count#} p $ fromIntegral $ length rW
         if length rW > 20
            then error "regs_write overflew 20 elements (40 bytes)"
            else pokeArray (plusPtr p {#offsetof cs_detail.regs_write#}) rW
-        {#set cs_detail->groups_count#} p $ fromIntegral $ length g
+        {#set cs_detail.groups_count#} p $ fromIntegral $ length g
         if length g > 8
            then error "groups overflew 8 bytes"
            else pokeArray (plusPtr p {#offsetof cs_detail.groups#}) g
-        let bP = plusPtr p $ {#offsetof cs_detail.groups_count#} + 1
+        let bP = plusPtr p $ {#offsetof cs_detail.x86#}
         case a of
           Just (X86 x) -> poke bP x
           Just (Arm64 x) -> poke bP x
@@ -246,7 +246,7 @@ instance Storable CsDetail where
 peekDetail :: CsArch -> Ptr CsDetail -> IO CsDetail
 peekDetail arch p = do
     detail <- peek p
-    let bP = plusPtr p {#offsetof cs_detail->x86#}
+    let bP = plusPtr p {#offsetof cs_detail.x86#}
     aI <- case arch of
             CsArchX86 -> X86 <$> peek bP
             CsArchArm64 -> Arm64 <$> peek bP
@@ -283,7 +283,7 @@ instance Storable CsInsn where
                let ptr = plusPtr p {#offsetof cs_insn->bytes#}
                peekArray num ptr
         <*> ((map castCCharToChar . takeWhile (/=0)) <$>
-            peekArray 32 (plusPtr p {#offsetof cs_insn->mnemonic#}))
+            peekArray {#const CS_MNEMONIC_SIZE#} (plusPtr p {#offsetof cs_insn->mnemonic#}))
         <*> ((map castCCharToChar . takeWhile (/=0)) <$>
             peekArray 160 (plusPtr p {#offsetof cs_insn->op_str#}))
         <*> return Nothing
@@ -327,7 +327,7 @@ peekArch arch p = do
 -- | an arch-sensitive peekElemOff for cs_insn
 peekElemOffArch :: CsArch -> Ptr CsInsn -> Int -> IO CsInsn
 peekElemOffArch arch ptr off =
-    peekArch arch (plusPtr ptr (off * sizeOf (undefined :: CsInsn)))
+    peekArch arch $ plusPtr ptr $ off * {#sizeof cs_insn#}
 
 -- | an arch-sensitive peekArray for cs_insn
 peekArrayArch :: CsArch -> Int -> Ptr CsInsn -> IO [CsInsn]

--- a/src/Hapstone/Internal/X86.chs
+++ b/src/Hapstone/Internal/X86.chs
@@ -248,7 +248,7 @@ instance Storable CsX86Encoding where
         <*> (fromIntegral <$> {#get cs_x86_encoding->imm_size#} p)
     poke p (CsX86Encoding moff doff dsize ioff isize) = do
         {#set cs_x86_encoding->modrm_offset#} p (fromIntegral moff)
-        {#set cs_x86_encoding->disp_size#} p (fromIntegral doff)
+        {#set cs_x86_encoding->disp_offset#} p (fromIntegral doff)
         {#set cs_x86_encoding->disp_size#} p (fromIntegral dsize)
         {#set cs_x86_encoding->imm_offset#} p (fromIntegral ioff)
         {#set cs_x86_encoding->imm_size#} p (fromIntegral isize)

--- a/src/Hapstone/Internal/X86.chs
+++ b/src/Hapstone/Internal/X86.chs
@@ -224,8 +224,8 @@ instance Storable CsX86Op where
               poke memP m
               setType X86OpMem
           Undefined -> setType X86OpInvalid
-        {#set cs_x86_op->size#} p (fromIntegral s)
-        {#set cs_x86_op->access#} p (fromIntegral a)
+        {#set cs_x86_op->size#} p $ fromIntegral s
+        {#set cs_x86_op->access#} p $ fromIntegral a
         {#set cs_x86_op->avx_bcast#} p $ fromIntegral $ fromEnum ab
         {#set cs_x86_op->avx_zero_opmask#} p az
 

--- a/src/Hapstone/Internal/X86.chs
+++ b/src/Hapstone/Internal/X86.chs
@@ -226,7 +226,7 @@ instance Storable CsX86Op where
           Undefined -> setType X86OpInvalid
         {#set cs_x86_op->size#} p (fromIntegral s)
         {#set cs_x86_op->access#} p (fromIntegral a)
-        {#set cs_x86_op->access#} p (fromIntegral $ fromEnum ab)
+        {#set cs_x86_op->avx_bcast#} p $ fromIntegral $ fromEnum ab
         {#set cs_x86_op->avx_zero_opmask#} p az
 
 data CsX86Encoding = CsX86Encoding

--- a/src/Hapstone/Internal/X86.chs
+++ b/src/Hapstone/Internal/X86.chs
@@ -278,7 +278,7 @@ data CsX86 = CsX86
     , avxCc :: X86AvxCc -- ^ AVX condition code
     , avxSae :: Bool -- ^ AXV Supress all Exception
     , avxRm :: X86AvxRm -- ^ AVX static rounding mode
-    , flags :: Word64 -- ^ flags updated by this instruction
+    , flags :: Word64 -- ^ flags updated by this instruction (a union of two different flag regs in C)
     , operands :: [CsX86Op] -- ^ operand list for this instruction, *MUST*
                             -- have <= 8 elements, else you'll get a runtime
                             -- error when you (implicitly) try to write it to

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,20 +1,11 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-15.10
-
-# Don't want resolver version of c2hs
-drop-packages:
-- c2hs
+resolver: lts-17.11
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-
-# # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-# extra-deps:
-# - git: https://github.com/haskell/c2hs
-#   commit: fbb4c2fa6ec5528aa068512f1b691298db420321
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,3 +35,6 @@ system-ghc: true
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+drop-packages:
+- c2hs # don't want resolver version!

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,10 +11,10 @@ drop-packages:
 packages:
 - '.'
 
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-- git: https://github.com/haskell/c2hs
-  commit: fbb4c2fa6ec5528aa068512f1b691298db420321
+# # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+# extra-deps:
+# - git: https://github.com/haskell/c2hs
+#   commit: fbb4c2fa6ec5528aa068512f1b691298db420321
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
 - git: https://github.com/haskell/c2hs
-  commit: e64e0b2de00c9566e1dd832d9a9b8285b80669ee
+  commit: fbb4c2fa6ec5528aa068512f1b691298db420321
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,10 @@
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 resolver: lts-15.10
 
+# Don't want resolver version of c2hs
+drop-packages:
+- c2hs
+
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
@@ -35,6 +39,3 @@ system-ghc: true
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
-
-drop-packages:
-- c2hs # don't want resolver version!

--- a/test/Internal/CapstoneSpec.hs
+++ b/test/Internal/CapstoneSpec.hs
@@ -45,7 +45,7 @@ csSkipdataStruct = CsSkipdataStruct "teststr"
 
 csSkipdataStructStorableSpec :: Spec
 csSkipdataStructStorableSpec = describe "Storable CsSkipdataStruct" $ do
-    it "is a packed struct" $ 
+    it "is a packed struct" $
         sizeOf (undefined :: CsSkipdataStruct) == 3 * sizeOf (0 :: WordPtr)
     it "has matching peek- and poke-implementations" $ property $
         \s@CsSkipdataStruct{} ->
@@ -64,21 +64,21 @@ getCsDetail = do
     -- space allocation
     ptr <- mallocArray (sizeOf csDetail) :: IO (Ptr Word8)
     -- regs_read
-    pokeArray (castPtr ptr :: Ptr Word8)
+    pokeArray (castPtr ptr :: Ptr Word16)
         [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB]
     -- regs_read_count
-    pokeByteOff ptr 12 (12 :: Word8)
+    pokeByteOff ptr 24 (12 :: Word8)
     -- regs_write
-    pokeArray (plusPtr ptr 13 :: Ptr Word8)
+    pokeArray (plusPtr ptr 26 :: Ptr Word16)
         [ 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB
         , 0xC, 0xD, 0xE, 0xF, 0x0, 0x1, 0x2, 0x3
         ]
     -- regs_write_count
-    pokeByteOff ptr 33 (20 :: Word8)
+    pokeByteOff ptr 66 (20 :: Word8)
     -- groups
-    pokeArray (plusPtr ptr 34 :: Ptr Word8) [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7]
+    pokeArray (plusPtr ptr 67 :: Ptr Word8) [0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7]
     -- groups_count
-    pokeByteOff ptr 42 (8 :: Word8)
+    pokeByteOff ptr 75 (8 :: Word8)
     peek (castPtr ptr) <* free ptr
 
 csDetail :: CsDetail

--- a/test/Internal/CapstoneSpec.hs
+++ b/test/Internal/CapstoneSpec.hs
@@ -93,7 +93,8 @@ csDetail = CsDetail
 csDetailStorableSpec :: Spec
 csDetailStorableSpec = describe "Storable CsDetail" $ do
     it "has a memory layout we can manage" $
-        sizeOf (undefined :: CsDetail) == 24 + 1 + 1 + 40 + 1 + 8 + 1 + 4 + 1480
+        -- Probably not necessary with CsDetail size being automatically calculated now
+        sizeOf (undefined :: CsDetail) == 24 + 1 + 1 + 40 + 1 + 8 + 1 + 4 + 1768
     it "has matching peek- and poke-implementations with no arch specifics" $
         property $ \s@CsDetail{} ->
             alloca (\p -> poke p s >> peek p) `shouldReturn` s

--- a/test/Internal/Default.hs
+++ b/test/Internal/Default.hs
@@ -65,4 +65,4 @@ instance Arbitrary CsInsn where
     arbitrary = CsInsn <$> arbitrary <*> arbitrary <*>
         (take 16 <$> arbitrary) <*>
         (take 31 <$> listOf (chr <$> elements [1..255])) <*>
-        (take 159 <$> listOf(chr <$> elements [1..255])) <*> pure Nothing
+        (take 159 <$> listOf (chr <$> elements [1..255])) <*> pure Nothing

--- a/test/Internal/X86/Default.hs
+++ b/test/Internal/X86/Default.hs
@@ -19,6 +19,8 @@ instance Arbitrary X86Reg where
 instance Arbitrary X86OpType where
     arbitrary = elements [minBound..maxBound]
 
+instance Arbitrary X86XopCc where
+    arbitrary = elements [minBound..maxBound]
 instance Arbitrary X86AvxBcast where
     arbitrary = elements [minBound..maxBound]
 instance Arbitrary X86SseCc where
@@ -44,11 +46,15 @@ instance Arbitrary CsX86Op where
         , pure Undefined
         ] <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
+instance Arbitrary CsX86Encoding where
+    arbitrary = CsX86Encoding <$> arbitrary <*> arbitrary <*> arbitrary <*>
+        arbitrary <*> arbitrary
+
 instance Arbitrary CsX86 where
     arbitrary = CsX86 <$> tuple <*> list <*> arbitrary <*>
         arbitrary <*> arbitrary <*> nZ <*> nZ <*> arbitrary <*>
         arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*>
-        arbitrary <*> (take 8 <$> arbitrary)
+        arbitrary <*> arbitrary <*> arbitrary <*> (take 8 <$> arbitrary) <*> arbitrary
         where tuple = (,,,) <$> nZ <*> nZ <*> nZ <*> nZ
               nZ :: (Arbitrary a, Eq a, Num a) => Gen (Maybe a)
               nZ = fromZero <$> arbitrary

--- a/test/Internal/X86/StorableSpec.hs
+++ b/test/Internal/X86/StorableSpec.hs
@@ -90,7 +90,8 @@ getCsX86 = do
 csX86 :: CsX86
 csX86 = CsX86 (Nothing, Just 0x1, Just 0x2, Just 0x3) [0x4, 0x5, 0x6, 0x7]
     0x0 0x20 0x21 Nothing (Just 0x01234567) X86RegAl 0x2 X86RegEdx
-    X86SseCcEq X86AvxCcEq True X86AvxRmRu [csX86Op]
+    X86XopCcEq X86SseCcEq X86AvxCcEq True X86AvxRmRu 0xDEADBEEF [csX86Op]
+    $ CsX86Encoding 0 0 0 0 0
 
 -- | CsX86 spec
 csX86Spec :: Spec


### PR DESCRIPTION
I had to update the `stack.yaml` resolver to have a version of c2hs that supports the anonymous union that was introduced in capstone, as stack was not utilizing the explicitly-specified version from `extra-deps`. I also switched to using `build-tool-depends` to put a lower bound on the version of `c2hs` that will be used just in case (it's currently listed as 0.28.7, which seems to work), and thus specified a minimum cabal version of 2 as that is when `build-tool-depends` was introduced.

I did try running the tests too but `stack test` fails due to missing StorableSpec/Default modules for Evm and several other architectures, and even when those are commented out in `hapstone.cabal` it fails due to improper types/incorrect function names when building `Internal.Arm.Default` and the like. I got the x86 tests working, at least (which is all I'm concerned with at the moment). I additionally had some issues with using `cs_detail` but that was due to me having conflicting capstone libraries installed, and once I'd purged all the old library files things worked perfectly.